### PR TITLE
Smaller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,24 @@ Jitter searches through GitHub for releases with `.tar.gz`, `.tgz`, `.zip` or `.
 ## Installing
 Using the `install.sh` script (recommended):
 ```
-wget -qO- https://raw.githubusercontent.com/sharpcdf/jitter/main/install.sh | bash
+wget -qO- https://github.com/sharpcdf/jitter/main/install.sh?raw=true | bash
 ```
-Through nimble:
+To pass flags such as `--force` or `--uninstall` use:
+```
+wget -qO- https://github.com/sharpcdf/jitter/main/install.sh?raw=true | bash -s -- --flag
+```
+Through Nimble:
 ```
 nimble install https://github.com/sharpcdf/jitter
 ```
 ## Notes
-- At the moment, jitter is being developed and you need at least version 0.3.0 to use the install script. Previous releases relied on an installer called Mug
-- You may encounter bugs as this project is still in development, please create an issue if you encounter anything wrong with jitter :)
+- Right now Jitter only supports GitHub.
+- At the moment, Jitter is being developed and you need at least version 0.3.0 to use the install script. Previous releases relied on an installer called Mug
+- You may encounter bugs as this project is still in development, please create an issue if you encounter anything wrong with Jitter :)
 
 ## Building
 Clone the repository and run `nimble build`.
-(You need to have nim and nimble installed).
+(You need to have Nim and Nimble installed).
 ```
 git clone https://github.com/sharpcdf/jitter
 cd jitter

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Jitter searches through GitHub(and hopefully soon more sources) for releases wit
 ## Installing
 Using the `install.sh` script (recommended):
 ```
-wget -qO- https://github.com/sharpcdf/jitter/main/install.sh?raw=true | bash
+wget -qO- https://raw.githubusercontent.com/sharpcdf/jitter/main/install.sh | bash
 ```
 To pass flags such as `--force` or `--uninstall` use:
 ```
-wget -qO- https://github.com/sharpcdf/jitter/main/install.sh?raw=true | bash -s -- --flag
+wget -qO- https://raw.githubusercontent.com/sharpcdf/jitter/main/install.sh | bash -s -- --flag
 ```
 Through Nimble:
 ```

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Jitter searches through GitHub(and hopefully soon more sources) for releases wit
 ## Installing
 Using the `install.sh` script (recommended):
 ```
-wget -qO- https://raw.githubusercontent.com/sharpcdf/jitter/main/install.sh | bash
+wget -qO- https://github.com/sharpcdf/jitter/blob/main/install.sh?raw=true  | bash
 ```
 To pass flags such as `--force` or `--uninstall` use:
 ```
-wget -qO- https://raw.githubusercontent.com/sharpcdf/jitter/main/install.sh | bash -s -- --flag
+wget -qO- https://github.com/sharpcdf/jitter/blob/main/install.sh?raw=true  | bash -s -- --flag
 ```
 Through Nimble:
 ```

--- a/install.sh
+++ b/install.sh
@@ -33,13 +33,9 @@ done
 if [[ $UNINSTALL ]]; then
   if [[ -d "$HOME/.jitter" ]]; then
     echo "You will delete all installed packages and Jitter itself."
-    read -n 1 -p "Do you want to continue? (y/N) "
-    echo
-    if [[ $REPLY =~ [Yy] ]]; then
-      rm -rf "$HOME/.jitter"
-      echo "Successfully uninstalled"
-      exit 0
-    fi
+    rm -rf "$HOME/.jitter"
+    echo "Successfully uninstalled"
+    exit 0
   else
     echo "Jitter is not installed"
     exit 1


### PR DESCRIPTION
- Removed confirmation from the install script to uninstall.
- Added instructions in the readme to pass flags wgetting it.
- Added note saying that Jitter only supports GitHub by now.
- Capitalized Jitter and Nimble in the readme.